### PR TITLE
Added venv block to begining of line + time and user@machine to the right side

### DIFF
--- a/classyTouch.zsh-theme
+++ b/classyTouch.zsh-theme
@@ -2,13 +2,23 @@
 # Author: Yaris Alex Gutierrez <yarisgutierrez@gmail.com>
 # Prompt is the Oh-my-zsh version of user Graawr's 'Classy Touch' themes on http://dotshare.it
 
-local current_dir='%{$fg[red]%}[%{$reset_color%}%~% %{$fg[red]%}]%{$reset_color%}'
-local git_branch='$(git_prompt_info)%{$reset_color%}'
+export VIRTUAL_ENV_DISABLE_PROMPT=1
 
+function virtualenv_info(){
+    if [ -n "$VIRTUAL_ENV" ]; then
+        echo "(%{$FG[006]%}${VIRTUAL_ENV##*/}%{$FG[109]%})─"
+    else
+        echo ''
+    fi
+}
 
-PROMPT="%(?,%{$fg[red]%}┌─╼${current_dir}%{$reset_color%} ${git_branch}
-%{$fg[red]%}└────╼%{$reset_color%} ,%{$fg[red]%}┌─╼${current_dir}%{$reset_color%} ${git_branch}
-%{$fg[red]%}└╼ %{$reset_color%} "
+local current_dir='%{$FG[109]%}[%{$FG[002]%}%2~%{$FG[109]%}]'
+local git_branch='$(git_prompt_info)'
+local venv="\$(virtualenv_info)"
 
-ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[red]%}["
-ZSH_THEME_GIT_PROMPT_SUFFIX="] %{$reset_color%}"
+PROMPT="%(?,%{$FG[109]%}┌${venv}${current_dir}${git_branch}
+%{$FG[109]%}└─╼%{$reset_color%} ,%{$FG[109]%}┌─╼${current_dir}${git_branch}
+%{$FG[109]%}└╼ %{$reset_color%} "
+
+ZSH_THEME_GIT_PROMPT_PREFIX="%{$FG[109]%}─[%{$FG[011]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$FG[109]%}]"

--- a/classyTouch.zsh-theme
+++ b/classyTouch.zsh-theme
@@ -15,10 +15,13 @@ function virtualenv_info(){
 local current_dir='%{$FG[109]%}[%{$FG[002]%}%2~%{$FG[109]%}]'
 local git_branch='$(git_prompt_info)'
 local venv="\$(virtualenv_info)"
+_lineup=$'\e[1A'
+_linedown=$'\e[1B'
+local time_d="%D{%H:%M}"
 
-PROMPT="%(?,%{$FG[109]%}┌${venv}${current_dir}${git_branch}
-%{$FG[109]%}└─╼%{$reset_color%} ,%{$FG[109]%}┌─╼${current_dir}${git_branch}
-%{$FG[109]%}└╼ %{$reset_color%} "
+PROMPT="%{$FG[109]%}┌${venv}${current_dir}${git_branch}
+%{$FG[109]%}└─╼%{$reset_color%} "
+RPROMPT="%{${_lineup}%}${FG[240]}╾[${time_d}]─[%n@%m]╼%{${_linedown}%}%{$reset_color%}"
 
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$FG[109]%}─[%{$FG[011]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$FG[109]%}]"


### PR DESCRIPTION
I really likes this theme, so I added 4 small things to it

- on the main side
  - Block for a virtual environment (python)
  - path only shows the parent/current path
- on the right side
  - time in `{%H:%M}` format
  - user@machine

Should look something like this:

```
┌(python_venv)─[parent/current]─[branch_123]                               ╾[14:47]─[user@machine]╼
└─╼ deactivate 
┌[parent/current]─[branch_123]                                             ╾[14:47]─[user@machine]╼
└─╼ cd
┌[~]                                                                       ╾[14:47]─[user@machine]╼
└─╼ cd Stuff
┌[~/Stuff]                                                                 ╾[14:47]─[user@machine]╼
└─╼
```